### PR TITLE
Fix docker build pybind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM ubuntu:20.04
 
 # install the build toolchain (gcc, cmake)
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y build-essential cmake python3 && \
+RUN apt-get update && apt-get install -y build-essential cmake \
+        python3 python3-distutils && \
+    # python3-pip (.deb not required because there's no pip package to be installed) \
+    # pip3 install pip --upgrade && pip3 install scikit-build && \
     rm -rf /var/lib/apt/lists/*
-
 
 # print the build toolchain versions
 RUN cmake --version && gcc --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ FROM ubuntu:20.04
 # install the build toolchain (gcc, cmake)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential cmake \
-        python3 python3-distutils && \
-    # python3-pip (.deb not required because there's no pip package to be installed) \
+        python3 python3-distutils python3-pip && \
     # pip3 install pip --upgrade && pip3 install scikit-build && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM ubuntu:20.04
 
 # install the build toolchain (gcc, cmake)
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y build-essential cmake && apt-get install python3 && \
+RUN apt-get update && apt-get install -y build-essential cmake python3 && \
     rm -rf /var/lib/apt/lists/*
-    
+
 
 # print the build toolchain versions
 RUN cmake --version && gcc --version

--- a/src/attack_bitboards.cpp
+++ b/src/attack_bitboards.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "attack_bitboards.h"
 
 namespace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 
 namespace py = pybind11;
 
-#define MAKE_VALUE(enum_, val) value(xstr(val), enum_##::##val)
+#define MAKE_VALUE(enum_, val) value(xstr(val), enum_::val)
 #define MAKE_SQUARE_VALUE(val) MAKE_VALUE(square,val)
 #define MAKE_PIECE_VALUE(val) MAKE_VALUE(piece_type, val)
 #define MAKE_MOVE_VALUE(val) MAKE_VALUE(move_type, val)


### PR DESCRIPTION
- docker build CI pipeline was broken due to adding pybind to the CMake build
- added several apt packages to the setup to make the docker build work again
- fixed some minor build issues in code files